### PR TITLE
Updating example with the given method.

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ gem 'pact-mock_service', '~> 0.4.1'
 
       it("should say hello", function(done) {
         helloProvider
+          .given("default server state")
           .uponReceiving("a request for hello")
           .withRequest("get", "/sayHello")
           .willRespondWith(200, {


### PR DESCRIPTION
As it is required to add `provider_state` to the JSON pact file.  Currently pact-jvm expects this to be there and will blow up if it ain't.
